### PR TITLE
Changed bean name to avoid conflict when pulling in another dependenc…

### DIFF
--- a/src/main/java/com/rei/ropeteam/spring/RopeTeamConfig.java
+++ b/src/main/java/com/rei/ropeteam/spring/RopeTeamConfig.java
@@ -16,7 +16,7 @@ import com.rei.ropeteam.OncePerClusterExecutor;
 
 @Configuration
 public class RopeTeamConfig {
-    
+
     @Bean
     @Scope(BeanDefinition.SCOPE_SINGLETON)
     public static OncePerClusterExecutor oncePerClusterExecutor(ApplicationContext ctx) {
@@ -32,13 +32,13 @@ public class RopeTeamConfig {
     public static OnePerClusterInterceptor onePerClusterInterceptor(OncePerClusterExecutor executor) {
         return new OnePerClusterInterceptor(executor);
     }
-    
+
     @Bean
     @Scope(BeanDefinition.SCOPE_SINGLETON)
-    public static ClusterEventBus eventBus(JChannel mainChannel) {
+    public static ClusterEventBus clusterEventBus(JChannel mainChannel) {
         return new ClusterEventBus(mainChannel);
     }
-    
+
     @Bean
     @Scope(BeanDefinition.SCOPE_SINGLETON)
     public static EventSubscriberRegistrar eventSubscriberRegistrar(ClusterEventBus bus, ApplicationContext applicationContext) {


### PR DESCRIPTION
AxonFramework defines a configuration for a `SimpleEventBus` in [AxonAutoConfiguration.java](https://axoniq.io/apidocs/4.0/org/axonframework/springboot/autoconfig/AxonAutoConfiguration.html) that initializes the bean instance with the name `eventBus`. This conflicts with `RopeTeamConfig`'s naming of the `ClusteredEventBus`. This pr simply changes the name of the `ClusteredEventBus` instance from `eventBus` to `clusteredEventBus`